### PR TITLE
Review frontend action and final phase code

### DIFF
--- a/frontend/src/app/retro/[id]/phases/ActionItemsPhase.tsx
+++ b/frontend/src/app/retro/[id]/phases/ActionItemsPhase.tsx
@@ -145,7 +145,7 @@ export default function ActionItemsPhase({
         </div>
 
         {/* Panel kanan */}
-        <div className="w-[400px] border-l bg-white flex flex-col p-6 h-full min-h-screen">
+        <div className="w-full border-t bg-white flex flex-col p-6 h-full min-h-screen lg:w-[400px] lg:border-l lg:border-t-0">
           <div className="flex items-center gap-2 mb-2 sticky top-0 z-10 bg-white">
             <span className="text-2xl">🚀</span>
             <span className="text-xl font-semibold">Action Items</span>

--- a/frontend/src/app/retro/[id]/phases/FinalPhase.tsx
+++ b/frontend/src/app/retro/[id]/phases/FinalPhase.tsx
@@ -92,7 +92,7 @@ export default function FinalPhase({
           </div>
         </div>
         {/* Panel kanan: Action Items (atau summary) */}
-        <div className="w-[400px] border-l bg-white flex flex-col p-6 h-full min-h-screen">
+        <div className="w-full border-t bg-white flex flex-col p-6 h-full min-h-screen lg:w-[400px] lg:border-l lg:border-t-0">
           {/* Header sticky */}
           <div className="flex items-center gap-2 mb-2 sticky top-0 z-10 bg-white">
             <span className="text-2xl">🚀</span>


### PR DESCRIPTION
Make ActionItems and FinalPhase right panels full-width on mobile to resolve UI truncation and right-side gap.

Previously, these panels maintained a fixed width on mobile, causing them to appear cut off and leaving an unwanted gap when stacked below the left panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9ac7789-c1bb-4534-b67c-63c6d91d5ab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9ac7789-c1bb-4534-b67c-63c6d91d5ab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

